### PR TITLE
Support es5 by default

### DIFF
--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -1,3 +1,4 @@
+const fs = require('fs-extra');
 const { join } = require('path');
 
 require('babel-register')({
@@ -25,12 +26,10 @@ module.exports = {
         StyleGuideRenderer: join(__dirname, 'src/styleguide/StyleGuideRenderer.jsx'),
       },
     }],
-    (neutrino) => {
-      if (neutrino.options.command === 'start') {
-        neutrino.config.module.rules.delete('lint');
-      }
-    },
     ['neutrino-preset-mozilla-frontend-infra/react-components', {
+      targets: {
+        browsers: 'ie 9',
+      },
       style: {
         extract: false,
       },
@@ -42,5 +41,16 @@ module.exports = {
         }
       },
     }],
+    (neutrino) => {
+      if (neutrino.options.command === 'start') {
+        neutrino.config.module.rules.delete('lint');
+      }
+
+      neutrino.on('build', () => {
+        ['package.json', 'logo.png', 'LICENSE', 'README.md', 'AUTHORS'].map(file => {
+          fs.copyFileSync(file, join(__dirname, `build/${file}`));
+        })
+      });
+    },
   ],
 };

--- a/package.json
+++ b/package.json
@@ -4,23 +4,19 @@
   "description": "Mozilla Front End Infra Shareable React Components",
   "repository": "mozilla-frontend-infra/components",
   "license": "MPL-2.0",
-  "main": "build/index.js",
+  "main": "./index.js",
   "scripts": {
     "changelog": "auto-changelog",
     "start": "neutrino styleguide:start",
     "build": "neutrino build",
-    "prepare": "neutrino build",
     "deploy": "neutrino styleguide:build && gh-pages --remote upstream -d styleguide",
     "lint": "neutrino lint",
+    "publish": "yarrn build && npm publish build",
     "update:authors": "scripts/authors"
   },
-  "files": [
-    "build",
-    "es5"
-  ],
   "devDependencies": {
     "@material-ui/core": "^1.3.1",
-    "auto-changelog": "^1.7.2",
+    "auto-changelog": "^1.8.0",
     "babel-register": "^6.26.0",
     "gh-pages": "^1.2.0",
     "neutrino": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "neutrino build",
     "deploy": "neutrino styleguide:build && gh-pages --remote upstream -d styleguide",
     "lint": "neutrino lint",
-    "publish": "yarrn build && npm publish build",
+    "publish": "yarn build && npm publish build",
     "update:authors": "scripts/authors"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -806,14 +806,15 @@ atob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.1.tgz#ae2d5a729477f289d60dd7f96a6314a22dd6c22a"
 
-auto-changelog@^1.7.2:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/auto-changelog/-/auto-changelog-1.7.2.tgz#f1c88b14f1c2c58617e263bc4127f93d6eae2067"
+auto-changelog@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/auto-changelog/-/auto-changelog-1.8.0.tgz#6312c93a007551e6eea8f28d05bd5efb3d88ea18"
   dependencies:
     babel-polyfill "^6.26.0"
     commander "^2.9.0"
     handlebars "^4.0.11"
     lodash.uniqby "^4.7.0"
+    node-fetch "^2.2.0"
     parse-github-url "^1.0.1"
     semver "^5.1.0"
 
@@ -6841,6 +6842,10 @@ node-fetch@^1.0.1:
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
+
+node-fetch@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.2.0.tgz#4ee79bde909262f9775f731e3656d0db55ced5b5"
 
 node-forge@0.7.5:
   version "0.7.5"


### PR DESCRIPTION
* Copy other files to the build directory
* Make the publish script only publish the build directory. This way we can have cleaner imports.

Resolves #4.