### PR TITLE
Add browserstack mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,9 @@ Open a browser to http://localhost:6060 to preview the React components.
 Feel free to open an issue, submit a pull request, or contribute however you would like. Understand that this
 documentation is still a work in progress, so file an issue or submit a PR to ask questions or make improvements.
 Thanks!
+
+## Thanks
+
+[<img src="https://www.browserstack.com/images/mail/browserstack-logo-footer.png" width="120">](https://www.browserstack.com/)
+
+Thank you to [BrowserStack](https://www.browserstack.com/) for providing the infrastructure that allows us to test in real browsers.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,6 @@ Thanks!
 
 ## Thanks
 
-[<img src="https://www.browserstack.com/images/mail/browserstack-logo-footer.png" width="120">](https://www.browserstack.com/)
+[![BrowserStack](https://www.browserstack.com/images/mail/browserstack-logo-footer.png)](https://www.browserstack.com/)
 
 Thank you to [BrowserStack](https://www.browserstack.com/) for providing the infrastructure that allows us to test in real browsers.


### PR DESCRIPTION
Browserstack offers a free subscription for open source projects but would like the projects that use it to give them a shoutout. We need to add this in return for a free subscription.

Browserstack will allow us to locally test components on all the browsers seamlessly. Material UI [uses](https://github.com/mui-org/material-ui#thanks) this service as well.