### PR TITLE
Change anchor color in Markdown component

### DIFF
--- a/src/components/Markdown/index.jsx
+++ b/src/components/Markdown/index.jsx
@@ -177,8 +177,8 @@ markdown.use(linkAttributes, {
     },
     '& a, & a code': {
       // Style taken from the Link component
-      color: theme.palette.secondary.main,
-      textDecoration: 'none',
+      color: theme.palette.error.contrastText,
+      textDecoration: 'underline',
       '&:hover': {
         textDecoration: 'underline',
       },

--- a/src/components/Markdown/index.jsx
+++ b/src/components/Markdown/index.jsx
@@ -178,10 +178,6 @@ markdown.use(linkAttributes, {
     '& a, & a code': {
       // Style taken from the Link component
       color: theme.palette.error.contrastText,
-      textDecoration: 'underline',
-      '&:hover': {
-        textDecoration: 'underline',
-      },
     },
     '& img': {
       maxWidth: '100%',


### PR DESCRIPTION
Color for the anchor is changed in order to fix the issue [#127](https://github.com/taskcluster/taskcluster-web/issues/127) at `taskcluster-web` repo. 