### PR TITLE
[UI] Remove defaultTabIndex warning in console

### DIFF
--- a/src/components/MarkdownTextArea/index.jsx
+++ b/src/components/MarkdownTextArea/index.jsx
@@ -106,7 +106,7 @@ export default class MarkdownTextArea extends Component {
   };
 
   render() {
-    const { classes, onChange, rows, markdownProps, ...props } = this.props;
+    const { classes, onChange, rows, markdownProps, defaultTabIndex, ...props } = this.props;
     const { tabIndex, value } = this.state;
     const isPreview = tabIndex === 1;
 


### PR DESCRIPTION
I don't know if I'm doing it right, but i think it can remove warning when we are passing "defaultTabIndex" as prop in MarkdownTextArea component
This is refers to [issue#1408 in taskcluster](https://github.com/taskcluster/taskcluster/issues/1408)