### PR TITLE
[UI] Remove defaultTabIndex warning in console #50

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "error-stack-parser": "^2.0.2",
     "highlight.js": "^9.12.0",
     "is-absolute-url": "^2.1.0",
-    "js-yaml": "^3.13.0",
+    "js-yaml": "^3.13.1",
     "jsonlint-mod": "^1.7.2",
     "markdown-it": "^8.4.2",
     "markdown-it-highlightjs": "^3.0.0",

--- a/src/components/MarkdownTextArea/index.jsx
+++ b/src/components/MarkdownTextArea/index.jsx
@@ -106,7 +106,8 @@ export default class MarkdownTextArea extends Component {
   };
 
   render() {
-    const { classes, onChange, rows, markdownProps, ...props } = this.props;
+    const { classes, rows, markdownProps } = this.props;
+    const { onChange, defaultTabIndex, ...props } = this.props;
     const { tabIndex, value } = this.state;
     const isPreview = tabIndex === 1;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7565,10 +7565,10 @@ js-yaml@3.12.0, js-yaml@^3.12.0, js-yaml@^3.9.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^3.13.0:
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.0.tgz#38ee7178ac0eea2c97ff6d96fff4b18c7d8cf98e"
-  integrity sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==
+js-yaml@^3.13.1:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"


### PR DESCRIPTION
This PR fixes the defaultTabIndex warning in console when clicking the "Preview" button in the MarkdownTextArea component in [ /hooks/garbage/abc456](url) on Taskcluster.
