### PR TITLE
Fix: Remove defaultTabIndex warning in console

### DIFF
--- a/src/components/MarkdownTextArea/index.jsx
+++ b/src/components/MarkdownTextArea/index.jsx
@@ -106,7 +106,8 @@ export default class MarkdownTextArea extends Component {
   };
 
   render() {
-    const { classes, onChange, rows, markdownProps, ...props } = this.props;
+    const { classes, rows, markdownProps } = this.props;
+    const { onChange, defaultTabIndex, ...props } = this.props;
     const { tabIndex, value } = this.state;
     const isPreview = tabIndex === 1;
 


### PR DESCRIPTION
This PR is to remove defaultTabIndex warning in console in the preview tab of the description box.
[hooks/garbage/abc456](url)
@helfi92 