### PR TITLE
Fix: Replace rem with em

### DIFF
--- a/src/components/Label/index.jsx
+++ b/src/components/Label/index.jsx
@@ -11,7 +11,7 @@ import palette from '../../utils/palette';
     padding: '4px 10px 3px',
   },
   mini: {
-    fontSize: '0.7rem',
+    fontSize: '0.7em',
     padding: '3px 8px 2px',
   },
   disabled: {

--- a/src/components/Markdown/index.jsx
+++ b/src/components/Markdown/index.jsx
@@ -21,7 +21,7 @@ markdown.use(linkAttributes, {
 @withStyles(theme => ({
   root: {
     fontFamily: theme.typography.fontFamily,
-    fontSize: '1rem',
+    fontSize: '1em',
     color: theme.palette.text.primary,
     '& > p': {
       margin: 0,
@@ -41,10 +41,10 @@ markdown.use(linkAttributes, {
       lineHeight: 1.6,
       fontFamily: 'Consolas, "Liberation Mono", Menlo, Courier, monospace',
       padding: '3px 6px',
-      fontSize: '0.875rem',
+      fontSize: '0.875em',
     },
     '& p code, & ul code, & pre code': {
-      fontSize: '0.875rem',
+      fontSize: '0.875em',
       lineHeight: 1.6,
     },
     '& h1': {
@@ -105,30 +105,30 @@ markdown.use(linkAttributes, {
       borderSpacing: 0,
       overflow: 'hidden',
       '& .prop-name': {
-        fontSize: '0.8125rem',
+        fontSize: '0.8125em',
         fontFamily: 'Consolas, "Liberation Mono", Menlo, monospace',
       },
       '& .required': {
         color: theme.palette.type === 'light' ? '#006500' : '#9bc89b',
       },
       '& .prop-type': {
-        fontSize: '0.8125rem',
+        fontSize: '0.8125em',
         fontFamily: 'Consolas, "Liberation Mono", Menlo, monospace',
         color: theme.palette.type === 'light' ? '#932981' : '#dbb0d0',
       },
       '& .prop-default': {
-        fontSize: '0.8125rem',
+        fontSize: '0.8125em',
         fontFamily: 'Consolas, "Liberation Mono", Menlo, monospace',
         borderBottom: `1px dotted ${theme.palette.text.hint}`,
       },
     },
     '& thead': {
-      fontSize: '0.875rem',
+      fontSize: '0.875em',
       fontWeight: theme.typography.fontWeightMedium,
       color: theme.palette.text.secondary,
     },
     '& tbody': {
-      fontSize: '0.875rem',
+      fontSize: '0.875em',
       lineHeight: 1.5,
       color: theme.palette.text.primary,
     },
@@ -146,7 +146,7 @@ markdown.use(linkAttributes, {
       paddingRight: 3 * theme.spacing(1),
     },
     '& td code': {
-      fontSize: '.8125rem',
+      fontSize: '.8125em',
       lineHeight: 1.6,
     },
     '& th': {


### PR DESCRIPTION
This would make sure components are well sized with respect to the parent rather than the root of the site.